### PR TITLE
Enable Javadoc generation and tag creation for release builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,10 @@ on:
           description: 'Remote host target path'
           required: true
 
+permissions:
+  # Required to create GitHub tags
+  contents: write
+
 jobs:
   build:
     name: "Build Palladio Artifact"
@@ -151,3 +155,8 @@ jobs:
         release-version: ${{ inputs.release-version }}
         link-path: ${{ env.PROJECT_DEPLOY_PATH }}
         
+    - name: Create GitHub Tag
+      if: ${{ inputs.release-version != '0.0.0' }}
+      uses: rickstaa/action-create-tag@v1
+      with:
+        tag: releases/${{ inputs.release-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,4 +160,4 @@ jobs:
       shell: bash
       run: |
         git tag -a v${{ inputs.release-version }} -m "tagging release version ${{ inputs.release-version }}"
-        git push origin releases/${{ inputs.release-version }}
+        git push origin v${{ inputs.release-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,5 +159,5 @@ jobs:
       if: ${{ inputs.release-version != '0.0.0' }}
       shell: bash
       run: |
-        git tag releases/${{ inputs.release-version }}
+        git tag -a v${{ inputs.release-version }} -m "tagging release version ${{ inputs.release-version }}"
         git push origin releases/${{ inputs.release-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,5 +159,7 @@ jobs:
       if: ${{ inputs.release-version != '0.0.0' }}
       shell: bash
       run: |
-        git tag -a v${{ inputs.release-version }} -m "tagging release version ${{ inputs.release-version }}"
-        git push origin v${{ inputs.release-version }}
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git tag -a releases/${{ inputs.release-version }} -m "tagging release version ${{ inputs.release-version }}"
+        git push origin releases/${{ inputs.release-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,6 +157,7 @@ jobs:
         
     - name: Create GitHub Tag
       if: ${{ inputs.release-version != '0.0.0' }}
-      uses: rickstaa/action-create-tag@v1
-      with:
-        tag: releases/${{ inputs.release-version }}
+      shell: bash
+      run: |
+        git tag releases/${{ inputs.release-version }}
+        git push origin releases/${{ inputs.release-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,10 +90,11 @@ jobs:
     - name: Verify with Maven
       shell: bash
       run: |
+        MAVEN_ARGS="-U clean verify ${{ inputs.release-version != '0.0.0' && '-DgenerateJavaDocForUpdatesite' || '' }}"
         if ${{ inputs.use-display-output }}; then
-            DISPLAY=:0 mvn -U clean verify
+            DISPLAY=:0 mvn $MAVEN_ARGS
         else
-            mvn -U clean verify
+            mvn $MAVEN_ARGS
         fi
       
     - name: Check deployment


### PR DESCRIPTION
### Changes

- Javadoc generation for the updatesite is now only performed during release builds.
- During release builds, a GitHub tag is now automatically created.

### Related PRs

- PalladioSimulator/Palladio-Build-MavenParent#63