### PR TITLE
Update stCarolas/setup-maven to v5.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
         java-version: ${{ inputs.java-version }}
 
     - name: Set up Maven
-      uses: stCarolas/setup-maven@v5
+      uses: stCarolas/setup-maven@v5.1
       with:
         maven-version: 3.9.16
     


### PR DESCRIPTION
Update setup-maven to 5.1 to remove warnings.
https://github.com/stCarolas/setup-maven/releases/tag/v5.1